### PR TITLE
replace rix_utilities with rix_calibration

### DIFF
--- a/ioc_rix_sp1k1_calc/ioc_rix_sp1k1_calc.py
+++ b/ioc_rix_sp1k1_calc/ioc_rix_sp1k1_calc.py
@@ -10,15 +10,15 @@ from caproto.server import AsyncLibraryLayer, PVGroup, pvproperty
 # Ignore motor moves smaller than this number
 DEADBAND = 0.05
 # Load path for scientist-modifiable utilities file
-DYNAMIC_PATH = "/cds/home/opr/rixopr/scripts/rix_utilities.py"
-DYNAMIC_NAME = "rix_utilities"
+DYNAMIC_PATH = "/cds/home/opr/rixopr/scripts/rix_calibration.py"
+DYNAMIC_NAME = "rix_calibration"
 
 
 class NoneRixDB:
     """
     Replacement for rix.db hutch-python imports.
 
-    We need to ignore any such imports if they are present in rix_utilities.py
+    We need to ignore any such imports if they are present in rix_calibration.py
     because this SIOC needs to start up without loading the entire rix
     beamline.
     """
@@ -31,9 +31,9 @@ sys.modules["rix.db"] = NoneRixDB()
 # Import the one specific file without ruining our python path
 # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
 spec = importlib.util.spec_from_file_location(DYNAMIC_NAME, DYNAMIC_PATH)
-rix_utilities = importlib.util.module_from_spec(spec)
-sys.modules[DYNAMIC_NAME] = rix_utilities
-spec.loader.exec_module(rix_utilities)
+rix_calibration = importlib.util.module_from_spec(spec)
+sys.modules[DYNAMIC_NAME] = rix_calibration
+spec.loader.exec_module(rix_calibration)
 
 
 class Ioc_rix_sp1k1_calc(PVGroup):
@@ -153,11 +153,11 @@ class Ioc_rix_sp1k1_calc(PVGroup):
 
     def calculate_energy(self) -> tuple[float, float]:
         """
-        Run the rix_utilities calculation for the energy and cff values.
+        Run the rix_calibration calculation for the energy and cff values.
         """
         if None in (self.g_pi_value, self.m_pi_value):
             return (0, 0)
-        return rix_utilities.calc_E(self.g_pi_value, self.m_pi_value)
+        return rix_calibration.calc_E(self.g_pi_value, self.m_pi_value)
 
     async def _update_bandwidth_calc(self, timestamp):
         """
@@ -168,11 +168,11 @@ class Ioc_rix_sp1k1_calc(PVGroup):
 
     def calculate_bandwidth(self) -> float:
         """
-        Run the rix_utilities calculation for the mono bandwidth.
+        Run the rix_calibration calculation for the mono bandwidth.
         """
         if None in (self.g_pi_value, self.m_pi_value, self.exit_gap_value):
             return 0
-        return rix_utilities.calc_BW(self.exit_gap_value, self.g_pi_value, self.m_pi_value)
+        return rix_calibration.calc_BW(self.exit_gap_value, self.g_pi_value, self.m_pi_value)
 
     async def _update_grating_calc(self, timestamp):
         """
@@ -183,8 +183,8 @@ class Ioc_rix_sp1k1_calc(PVGroup):
 
     def calculate_grating(self) -> str:
         """
-        Run the rix_utilities calculation for the grating identi.
+        Run the rix_calibration calculation for the grating identi.
         """
         if self.g_h_value is None:
             return ""
-        return rix_utilities.get_grating()
+        return rix_calibration.get_grating()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`sed -i 's/rix_utilities/rix_calibration/g' ioc_rix_sp1k1_calc/ioc_rix_sp1k1_calc.py`

I took all the functions and relevant import statements out of rix_utilities and put it into a new file called rix_calibration.py which rix_utilities imports. This ioc now only imports rix_calibration, so changes to other utilities shouldn't affect it. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-6939
https://jira.slac.stanford.edu/browse/ECS-6936

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It's running right now. Startup and pvs look good to me. I also tried rix_utilities in rix3
![image](https://github.com/user-attachments/assets/da9aa6ac-1a73-40db-a41d-513820cce1f1)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Comments have been updated to say rix_calibration instead of rix_utilities. I also put this in rix_utilities
![image](https://github.com/user-attachments/assets/fd2a0c19-c91a-47e2-9634-4cad8ed87db8)


<!--
## Screenshots (if appropriate):
-->
![image](https://github.com/user-attachments/assets/6423b515-d318-403e-9f85-f74f1c9c3257)
